### PR TITLE
fix: fixed to be compatible with Flutter for Web (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,7 @@
 
 * `MultiCodec` list is now publicly accessible.
 * `MultihashInfo` class now outputs the correct information.
+
+## 0.2.1
+
+* Fixed to be compatible with Flutter for Web.

--- a/lib/src/multihash/varint_utils.dart
+++ b/lib/src/multihash/varint_utils.dart
@@ -6,7 +6,7 @@ import 'package:buffer/buffer.dart';
 import 'models.dart';
 
 /// Maximum safe integer in JavaScript. (2^53)
-const _maxIntegerJS = 9007199254740992;
+const _maxIntegerJS = 9007199254740991;
 
 /// Converts an int value to a varint (in Dart this is expressed as Uint8List - an array of bytes)
 /// This is an implementation of varint (changed for unsigned ints) based of https://github.com/fmoo/python-varint/blob/master/varint.py

--- a/lib/src/multihash/varint_utils.dart
+++ b/lib/src/multihash/varint_utils.dart
@@ -6,18 +6,18 @@ import 'package:buffer/buffer.dart';
 import 'models.dart';
 
 /// Maximum safe integer in JavaScript. (2^53)
-const _maxSafeIntegerJS = 9007199254740992;
+const _maxIntegerJS = 9007199254740992;
 
 /// Converts an int value to a varint (in Dart this is expressed as Uint8List - an array of bytes)
 /// This is an implementation of varint (changed for unsigned ints) based of https://github.com/fmoo/python-varint/blob/master/varint.py
 /// that is changed for unsigned integers.
 Uint8List encodeVarint(int value) {
   // Ensure that the value is within JavaScript's safe integer range.
-  if (value < 0 || value >= _maxSafeIntegerJS) {
+  if (value < 0 || value >= _maxIntegerJS) {
     throw ArgumentError.value(
       value,
       'value',
-      'must be a non-negative integer less than $_maxSafeIntegerJS',
+      'must be a non-negative integer less than $_maxIntegerJS',
     );
   }
 

--- a/lib/src/multihash/varint_utils.dart
+++ b/lib/src/multihash/varint_utils.dart
@@ -5,16 +5,28 @@ import 'package:buffer/buffer.dart';
 
 import 'models.dart';
 
+/// Maximum safe integer in JavaScript. (2^53)
+const _maxSafeIntegerJS = 9007199254740992;
+
 /// Converts an int value to a varint (in Dart this is expressed as Uint8List - an array of bytes)
 /// This is an implementation of varint (changed for unsigned ints) based of https://github.com/fmoo/python-varint/blob/master/varint.py
 /// that is changed for unsigned integers.
 Uint8List encodeVarint(int value) {
+  // Ensure that the value is within JavaScript's safe integer range.
+  if (value < 0 || value >= _maxSafeIntegerJS) {
+    throw ArgumentError.value(
+      value,
+      'value',
+      'must be a non-negative integer less than $_maxSafeIntegerJS',
+    );
+  }
+
   ByteDataWriter writer = ByteDataWriter();
 
   do {
     int temp = value & 0x7F; //0x7F = 01111111
 
-    value = (value >> 7) & 0x01FFFFFFFFFFFFFF; // unsigned bit-right shift
+    value = value >> 7;
 
     if (value != 0) {
       temp |= 0x80;

--- a/lib/src/multihash/varint_utils.dart
+++ b/lib/src/multihash/varint_utils.dart
@@ -24,9 +24,9 @@ Uint8List encodeVarint(int value) {
   ByteDataWriter writer = ByteDataWriter();
 
   do {
-    int temp = value & 0x7F; //0x7F = 01111111
+    int temp = value & 0x7F; // 0x7F = 01111111
 
-    value = value >> 7;
+    value = value >> 7; // unsigned bit-right shift
 
     if (value != 0) {
       temp |= 0x80;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_multihash
 description: A dart-lang implementation of the Multihash protocol.
-version: 0.2.0
+version: 0.2.1
 homepage: https://github.com/dwyl/dart_multihash
 repository: https://github.com/dwyl/dart_multihash
 issue_tracker: https://github.com/dwyl/dart_multihash/issues

--- a/test/dart_varint_test.dart
+++ b/test/dart_varint_test.dart
@@ -7,10 +7,11 @@ import 'package:collection/collection.dart';
 void main() {
   test('encoding varint', () {
     int value = 1000;
-    Uint8List expectedOutput = Uint8List.fromList([232, 7]); // decimal 1000 is equivalent to [232, 7] in bytes array
+    Uint8List expectedOutput = Uint8List.fromList(
+        [232, 7]); // decimal 1000 is equivalent to [232, 7] in bytes array
 
     Uint8List output = encodeVarint(value);
-    
+
     Function eq = const ListEquality().equals;
     expect(eq(expectedOutput, output), true);
   });
@@ -18,7 +19,8 @@ void main() {
   test('decoding varint', () {
     // The following is input byte array and the correspondent value.
     int inputValue = 3463580742760;
-    Uint8List inputValueInByteArray = Uint8List.fromList([232, 232, 255, 235, 230, 100]);
+    Uint8List inputValueInByteArray =
+        Uint8List.fromList([232, 232, 255, 235, 230, 100]);
 
     var output = decodeVarint(inputValueInByteArray, null);
 
@@ -26,7 +28,23 @@ void main() {
   });
 
   test('decoding varint invalid varint (out of bounds)', () {
-    Uint8List input = Uint8List.fromList([232, 232, 255, 235, 230, 150]); // this varint is not finished being defined
+    Uint8List input = Uint8List.fromList([
+      232,
+      232,
+      255,
+      235,
+      230,
+      150
+    ]); // this varint is not finished being defined
     expect(() => decodeVarint(input, null), throwsA(TypeMatcher<RangeError>()));
+  });
+
+  test('encoding unsafe value in JavaScript', () {
+    const maxUnsafeIntegerJS = 9007199254740992;
+
+    expect(
+      () => encodeVarint(maxUnsafeIntegerJS),
+      throwsA(isA<ArgumentError>()),
+    );
   });
 }


### PR DESCRIPTION
Hi,

I implemented one solution mentioned in #7. However, I am not a very expert in this field, so perhaps the elimination of the mask operation may cause problem with the standard specifications. Please verify this point.

But at least my assumption was that if we guarantee the value of `value` variable as the maximum number within the allowable range of JavaScript, the mask operation would be unnecessary.