### PR TITLE
[PR] Return MultihashInfo instead of just array of bytes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,8 @@
 ## 0.2.1
 
 * Fixed to be compatible with Flutter for Web.
+
+## 1.0.0
+
+* `encode` returns `MultihashInfo`.
+* `MultihashInfo` can be translated to bytes with `toBytes()`.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ standard.
 - `name` is the name of the hash function.
 - `code` is the code of the hash function.
 
-We recommend you checking https://cid.ipfs.tech/#bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+We recommend checking:
+https://cid.ipfs.tech/#bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
 to inspect a CID and see these parameters explained.
 
 ## Supported Algorithms

--- a/README.md
+++ b/README.md
@@ -48,13 +48,14 @@ Digest digest = sha256.convert(bytes);
 Uint8List inputByteArray = Uint8List.fromList(digest.bytes);
 
 // Encoding the hash digest with the Multihash standard.
-Uint8List encodedObj = Multihash.encode('sha2-256', inputByteArray);
+MultihashInfo encodedObj = Multihash.encode('sha2-256', inputByteArray);
+UInt8List encodedBytes = encodedObj.toBytes();
 
 // If we want to decode a Multihash-encoded hash, simply use `decode`.
-MultihashInfo decodedObj = Multihash.decode(encodedObj);
+MultihashInfo decodedObj = Multihash.decode(encodedBytes);
 ```
 
-If we were to inspect the `decodedObj`, 
+If we were to inspect `MultihashInfo`, 
 we would get access to the following info.
 
 ```dart
@@ -75,7 +76,7 @@ standard.
 - `name` is the name of the hash function.
 - `code` is the code of the hash function.
 
-We recommend you check https://cid.ipfs.tech/#bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
+We recommend you checking https://cid.ipfs.tech/#bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi
 to inspect a CID and see these parameters explained.
 
 ## Supported Algorithms

--- a/lib/src/multihash.dart
+++ b/lib/src/multihash.dart
@@ -8,7 +8,7 @@ import './multihash/models.dart';
 /// hash strings.
 class Multihash {
   /// Encodes a digest with a passed hash function type.
-  static Uint8List encode(String hashType, Uint8List digest, {int? length}) {
+  static MultihashInfo encode(String hashType, Uint8List digest, {int? length}) {
     // Checking if hash function type is supported
     if (!supportedHashFunctions.contains(hashType)) {
       throw UnsupportedError('Unsupported hash function type.');
@@ -23,14 +23,7 @@ class Multihash {
       throw RangeError('Digest length has to be equal to the specified length.');
     }
 
-    // Building the array of bytes with hash function type,
-    // length of digest and digest encoded.
-    var b = BytesBuilder();
-    b.add(encodeVarint(hashInfo.code));
-    b.add(encodeVarint(length));
-    b.add(digest);
-
-    return b.toBytes();
+    return MultihashInfo(code: hashInfo.code, name: hashInfo.name, digest: digest, size: length);
   }
 
   /// Decodes an array of bytes into a multihash object.

--- a/lib/src/multihash/models.dart
+++ b/lib/src/multihash/models.dart
@@ -1,3 +1,7 @@
+import 'dart:typed_data';
+
+import 'varint_utils.dart';
+
 /// Class with information regarding the [name]
 /// and the [code] that identifies it.
 ///
@@ -11,7 +15,7 @@ class MultiCodec {
 
 /// Class that holds information regarding a digest
 /// and the referring Multihash information.
-/// 
+///
 /// [digest] is the digest of the multihash.
 /// [size] is the length of the digest.
 /// [name] is the name of the hash function.
@@ -23,6 +27,17 @@ class MultihashInfo {
   final int code;
 
   const MultihashInfo({required this.code, required this.name, required this.digest, required this.size});
+
+  /// Builds the array of bytes with hash function type, length of digest and digest.
+  Uint8List toBytes() {
+
+    var b = BytesBuilder();
+    b.add(encodeVarint(code));
+    b.add(encodeVarint(size));
+    b.add(digest);
+
+    return b.toBytes();
+  }
 }
 
 /// Util class used to fetch the leading variable integer of a stream/array of bytes.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_multihash
 description: A dart-lang implementation of the Multihash protocol.
-version: 0.2.1
+version: 1.0.0
 homepage: https://github.com/dwyl/dart_multihash
 repository: https://github.com/dwyl/dart_multihash
 issue_tracker: https://github.com/dwyl/dart_multihash/issues

--- a/test/dart_multihash_test.dart
+++ b/test/dart_multihash_test.dart
@@ -39,7 +39,7 @@ void main() {
     Digest digest = sha256.convert(bytes);
     Uint8List inputByteArray = Uint8List.fromList(digest.bytes);
 
-    Uint8List encodedObj = Multihash.encode('sha2-256', inputByteArray);
+    Uint8List encodedObj = Multihash.encode('sha2-256', inputByteArray).toBytes();
     MultihashInfo decodedObj = Multihash.decode(encodedObj);
 
     Function eq = const ListEquality().equals;
@@ -73,7 +73,7 @@ void main() {
     Digest digest = sha256.convert(bytes);
     Uint8List inputByteArray = Uint8List.fromList(digest.bytes);
 
-    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray);
+    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray).toBytes();
     Uint8List splicedInvalidEncodedArray = encodedArray.sublist(0, 2);
 
     expect(() => Multihash.decode(splicedInvalidEncodedArray), throwsA(TypeMatcher<RangeError>()));
@@ -86,7 +86,7 @@ void main() {
     Digest digest = sha256.convert(bytes);
     Uint8List inputByteArray = Uint8List.fromList(digest.bytes);
 
-    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray);
+    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray).toBytes();
     Uint8List splicedInvalidEncodedArray = encodedArray.sublist(0, 2);
 
     expect(() => Multihash.decode(splicedInvalidEncodedArray), throwsA(TypeMatcher<RangeError>()));
@@ -99,7 +99,7 @@ void main() {
     Digest digest = sha256.convert(bytes);
     Uint8List inputByteArray = Uint8List.fromList(digest.bytes);
 
-    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray);
+    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray).toBytes();
     Uint8List splicedInvalidEncodedArray = encodedArray.sublist(0, 2);
 
     expect(() => Multihash.decode(splicedInvalidEncodedArray), throwsA(TypeMatcher<RangeError>()));
@@ -112,7 +112,7 @@ void main() {
     Digest digest = sha256.convert(bytes);
     Uint8List inputByteArray = Uint8List.fromList(digest.bytes);
 
-    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray);
+    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray).toBytes();
     encodedArray[0] = -1; // adding unsupported code
 
     expect(() => Multihash.decode(encodedArray), throwsA(TypeMatcher<UnsupportedError>()));
@@ -125,7 +125,7 @@ void main() {
     Digest digest = sha256.convert(bytes);
     Uint8List inputByteArray = Uint8List.fromList(digest.bytes);
 
-    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray);
+    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray).toBytes();
     encodedArray[1] = 0; // adding unsupported code
 
     expect(() => Multihash.decode(encodedArray), throwsA(TypeMatcher<RangeError>()));
@@ -138,7 +138,7 @@ void main() {
     Digest digest = sha256.convert(bytes);
     Uint8List inputByteArray = Uint8List.fromList(digest.bytes);
 
-    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray);
+    Uint8List encodedArray = Multihash.encode('sha2-256', inputByteArray).toBytes();
     encodedArray[1] = 1; // adding wrong length
 
     expect(() => Multihash.decode(encodedArray), throwsA(TypeMatcher<RangeError>()));


### PR DESCRIPTION
This will be needed to properly address the issue https://github.com/dwyl/dart_cid/issues/6#event-9730227216.

`encode` now returns a `MultihashInfo` object with the info of the created Multihash instead of an array of bytes. 